### PR TITLE
ZMS-644:Broken nginx.conf.mail

### DIFF
--- a/conf/nginx/nginx.conf.mail.template
+++ b/conf/nginx/nginx.conf.mail.template
@@ -218,7 +218,7 @@ mail
 
     # Sets the time-to-live of the list of servers for which no ip throttling
     # will be done
-    ${mail_whitelist_ip_ttl}        ${mail.whitelist.ttl};
+    mail_whitelist_ip_ttl   ${mail.whitelist.ttl};
 
     # Issue POP3 XOIP before logging in to upstream (Audit purposes)
     #


### PR DESCRIPTION
Problem:
    zmproxyctl restart
    Stopping proxy...proxy is not running.
    Starting proxy...nginx: [emerg] unknown directive "300" in /opt/zimbra/conf/nginx/includes/nginx.conf.mail:221
    failed.

Cause `${mail_whitelist_ip_ttl}` gets replaced with nothing, so end up
with just 300 on the line which is the value of `${mail.whitelist.ttl}`