### PR TITLE
Bug 108299: Send a proper HTTP status code for unknown Hosts

### DIFF
--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -17,7 +17,7 @@ server {
     ssl_verify_client       ${ssl.clientcertmode.default};
     ssl_verify_depth        ${ssl.clientcertdepth.default};
     ${web.ssl.dhparam.enabled}ssl_dhparam             ${web.ssl.dhparam.file};
-    return 444;
+    return 400;
 }
 
 server


### PR DESCRIPTION
The workaround/fix for bug 107963 results in a situation which is hard
to debug if the server isn't configured properly since nginx will just
close the TCP connection instead of returning something one can google.

This changes the status code to 400 which should be the proper response
if I interpret RFC 7230 section 5.4 correctly.

This still doesn't fix bug 108299 which results in a broken default install
under certain conditions but improves the situation.