### PR TITLE
Log the Host header and server address

### DIFF
--- a/conf/nginx/nginx.conf.web.template
+++ b/conf/nginx/nginx.conf.web.template
@@ -110,8 +110,8 @@ http
 
     # Enable Access logs for web traffic
     log_format upstream '$remote_addr:$remote_port - $remote_user [$time_local]  '
-      '"$request" $status $bytes_sent '
-      '"$http_referer" "$http_user_agent" "$upstream_addr"';
+      '"$request_method $scheme://$host$request_uri $server_protocol" $status $bytes_sent '
+      '"$http_referer" "$http_user_agent" "$upstream_addr" "$server_addr:$server_port"';
     access_log ${web.logfile} upstream;
 
     # Set proxy timeout


### PR DESCRIPTION
This modification was inspired by [this](https://forums.zimbra.org/viewtopic.php?f=59&t=62882) forum post and the changes discussed in #6. I needed a similar functionality before and the changed log format was actually taken from our production system.

This change extends the `log_format`
* to log the value of the `Host` header and request scheme
* to log the server address and port

To log the former, the third fifth field was changed from

    "$request"

to

    "$request_method $scheme://$host$request_uri $server_protocol"

With the results as shown in the examples below. This could require a change in possible third party log parsers but a field like this should have be expected as well since some (fishy) clients send a full URL here.

To log the latter, the field

    "$server_addr:$server_port"

was added to the end of the line.  Logically it should probably come before the `"$upstream_addr"` field but I added it to the end to minimize the changes required by third party log parsers.

This means that the log format changes from eg.

    172.31.1.252:19394 - - [10/Oct/2017:08:33:47 +0000]  "HEAD / HTTP/1.1" 200 378 "-" "curl/7.47.0" "172.31.4.202:8443"

to

    172.31.1.252:19988 - - [10/Oct/2017:08:39:22 +0000]  "HEAD https://mail.example.com/ HTTP/1.1" 200 378 "-" "curl/7.47.0" "172.31.4.202:8443" "172.31.4.202:443"
