### PR TITLE
Added configuration for zimbra-docs, to be used with the changes in t…

### DIFF
--- a/conf/nginx/nginx.conf.docs.common.template
+++ b/conf/nginx/nginx.conf.docs.common.template
@@ -1,0 +1,20 @@
+!{explode server(docs)}
+
+# static files
+location ^~ /docs/${server_id}/loleaflet {
+    rewrite /docs/${server_id}/(.*) /$1 break;
+    proxy_pass http://docs-${server_id};
+    proxy_set_header Host $http_host;
+    proxy_http_version 1.1;
+}
+
+# websockets, download, presentation and image upload
+location ^~ /docs/${server_id}/lool {
+    rewrite  ^  $request_uri;            # get original URI
+    rewrite /docs/${server_id}/(.*) /$1 break;
+    proxy_pass http://docs-${server_id}$uri;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $http_host;
+    proxy_http_version 1.1;
+}

--- a/conf/nginx/nginx.conf.docs.upstream.template
+++ b/conf/nginx/nginx.conf.docs.upstream.template
@@ -1,0 +1,5 @@
+!{explode server(docs)}
+upstream docs-${server_id}
+{
+  server ${server_hostname}:9980;
+}

--- a/conf/nginx/nginx.conf.web.http.default.template
+++ b/conf/nginx/nginx.conf.web.http.default.template
@@ -406,4 +406,6 @@ server
         # for custom error pages, internal use only
         internal;
     }
+
+    include                 ${core.includes}/${core.cprefix}.docs.common;
 }

--- a/conf/nginx/nginx.conf.web.http.template
+++ b/conf/nginx/nginx.conf.web.http.template
@@ -407,5 +407,7 @@ server
         # for custom error pages, internal use only
         internal;
     }
+
+    include                 ${core.includes}/${core.cprefix}.docs.common;
 }
 

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -510,4 +510,6 @@ server
         # for custom error pages, internal use only
         internal;
     }
+
+    include                 ${core.includes}/${core.cprefix}.docs.common;
 }

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -481,5 +481,7 @@ server
         # for custom error pages, internal use only
         internal;
     }
+
+    include                 ${core.includes}/${core.cprefix}.docs.common;
 }
 

--- a/conf/nginx/nginx.conf.web.template
+++ b/conf/nginx/nginx.conf.web.template
@@ -72,6 +72,8 @@ http
         zmauth_admin;
     }
 
+    include                 ${core.includes}/${core.cprefix}.docs.upstream;
+
     #  Define the collection of upstream HTTP EWS servers to which we will
     #  proxy EWS request. Define each server:port against a server directive
     #


### PR DESCRIPTION
Added configuration for zimbra-docs, to be used with the changes in the ProxyConfGen.
One upstream per server is required due to LOOLWSD architecture.

see https://github.com/Zimbra/zm-mailbox/pull/659 for the implementation of !{explode server(serviceName)}