### PR TITLE
Target 8.8.10 - Added upstreams towards dedicated http/https ports in mailboxd and co…

### DIFF
--- a/conf/nginx/nginx.conf.web.http.default.template
+++ b/conf/nginx/nginx.conf.web.http.default.template
@@ -160,6 +160,22 @@ server
         proxy_redirect http://$relhost/ http://$http_host/;
     }
 
+    location ^~ /zx/ws-
+    {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_pass ${web.upstream.zx};
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $http_host;
+      proxy_http_version 1.1;
+    }
+
+    location ^~ /zx/
+    {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass ${web.upstream.zx};
+    }
+
     # For NoOpRequest
     location ^~ /service/soap/NoOpRequest {
     

--- a/conf/nginx/nginx.conf.web.http.template
+++ b/conf/nginx/nginx.conf.web.http.template
@@ -161,6 +161,22 @@ server
         proxy_redirect http://$relhost/ http://$http_host/;
     }
 
+    location ^~ /zx/ws-
+    {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_pass ${web.upstream.zx};
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $http_host;
+      proxy_http_version 1.1;
+    }
+
+    location ^~ /zx/
+    {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass ${web.upstream.zx};
+    }
+
     # For NoOpRequest
     location ^~ /service/soap/NoOpRequest {
 

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -231,6 +231,22 @@ server
         proxy_redirect http://$relhost/ https://$http_host/;
     }
 
+    location ^~ /zx/ws-
+    {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_pass ${web.upstream.zx};
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $http_host;
+      proxy_http_version 1.1;
+    }
+
+    location ^~ /zx/
+    {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass ${web.upstream.zx};
+    }
+
     # For NoOpRequest
     location ^~ /service/soap/NoOpRequest {
 

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -202,6 +202,22 @@ server
         proxy_redirect http://$relhost/ https://$http_host/;
     }
 
+    location ^~ /zx/ws-
+    {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_pass ${web.upstream.zx};
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $http_host;
+      proxy_http_version 1.1;
+    }
+
+    location ^~ /zx/
+    {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass ${web.upstream.zx};
+    }
+
     # For NoOpRequest
     location ^~ /service/soap/NoOpRequest {
 

--- a/conf/nginx/nginx.conf.web.template
+++ b/conf/nginx/nginx.conf.web.template
@@ -54,6 +54,20 @@ http
         zmauth;
     }
 
+    #  Define the collection of upstream HTTP servers to dedicated zx port of jetty
+    upstream ${web.upstream.zx.name}
+    {
+        ${web.upstream.zx.:servers}
+        zmauth;
+    }
+
+    #  Define the collection of upstream HTTPS servers to dedicated zx ssl port of jetty
+    upstream ${web.ssl.upstream.zx.name}
+    {
+        ${web.ssl.upstream.zx.:servers}
+        zmauth;
+    }
+
      #  Define the collection of upstream admin client servers to which we will
     #  proxy. Define each server:port against a server directive
     #


### PR DESCRIPTION
Added upstream to dedicated http/https ports, this allocate the path /zx/ for general purposes and /zx/ws-* for websockets. 
This is needed for new drive websocket and in near future for chat.

Dependent on the PR for config generation: https://github.com/Zimbra/zm-mailbox/pull/765