### PR TITLE
ZCS-8569 ssl update

### DIFF
--- a/conf/nginx/nginx.conf.mail.imaps.default.template
+++ b/conf/nginx/nginx.conf.mail.imaps.default.template
@@ -2,17 +2,15 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${mail.imaps.port} ipv6only=off;
-    ${core.ipv4only.enabled}listen                ${mail.imaps.port};
+    ${core.ipboth.enabled}listen                  [::]:${mail.imaps.port} ipv6only=off ssl;
+    ${core.ipv4only.enabled}listen                ${mail.imaps.port} ssl;
     ${core.ipv6only.enabled}listen                [::]:${mail.imaps.port};
     ${web.ssl.dhparam.enabled}ssl_dhparam         ${web.ssl.dhparam.file};
     protocol            imap;
     proxy               on;
     timeout             ${mail.imap.timeout};
     proxy_timeout       ${mail.imap.proxytimeout};
-    ssl                 on;
     ssl_certificate     ${ssl.crt.default};
     ssl_certificate_key ${ssl.key.default};
     sasl_service_name   "imap";
 }
-

--- a/conf/nginx/nginx.conf.mail.pop3s.default.template
+++ b/conf/nginx/nginx.conf.mail.pop3s.default.template
@@ -2,17 +2,15 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen              [::]:${mail.pop3s.port} ipv6only=off;
-    ${core.ipv4only.enabled}listen            ${mail.pop3s.port};
-    ${core.ipv6only.enabled}listen            [::]:${mail.pop3s.port};
+    ${core.ipboth.enabled}listen              [::]:${mail.pop3s.port} ipv6only=off ssl;
+    ${core.ipv4only.enabled}listen            ${mail.pop3s.port} ssl;
+    ${core.ipv6only.enabled}listen            [::]:${mail.pop3s.port} ssl;
     ${web.ssl.dhparam.enabled}ssl_dhparam     ${web.ssl.dhparam.file};
     protocol            pop3;
     proxy               on;
     timeout             ${mail.pop3.timeout};
     proxy_timeout       ${mail.pop3.proxytimeout};
-    ssl                 on;
     ssl_certificate     ${ssl.crt.default};
     ssl_certificate_key ${ssl.key.default};
     sasl_service_name   "pop";
 }
-


### PR DESCRIPTION
Update the Nginx configuration files to move the `ssl on` to the end of the `listen` lines.
This is in preparation for upgrading to Nginx 1.17.9.

Warning message below:

```
Starting proxy...nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /opt/zimbra/conf/nginx/includes/nginx.conf.mail.imaps.default:13
nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /opt/zimbra/conf/nginx/includes/nginx.conf.mail.pop3s.default:13
nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /opt/zimbra/conf/nginx/includes/nginx.conf.web.https.default:40
nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /opt/zimbra/conf/nginx/includes/nginx.conf.web.admin.default:10
```