### PR TITLE
Rewrite Host attribute on zx upstream.

### DIFF
--- a/conf/nginx/nginx.conf.web.http.default.template
+++ b/conf/nginx/nginx.conf.web.http.default.template
@@ -173,6 +173,7 @@ server
     location ^~ /zx/
     {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
     }
 

--- a/conf/nginx/nginx.conf.web.http.template
+++ b/conf/nginx/nginx.conf.web.http.template
@@ -174,6 +174,7 @@ server
     location ^~ /zx/
     {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
     }
 

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -260,6 +260,7 @@ server
     location ^~ /zx/
     {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
     }
 

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -215,6 +215,7 @@ server
     location ^~ /zx/
     {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
     }
 


### PR DESCRIPTION
Hi,
trying to access the current domain using the "Host" header we noticed that the set_header has been added only to the "/zx/ws-" location and not to the "/zx"
This prohibits us to lookup the correct domain using the virtual host since the host is always "zx"
For this reason, we need to add the 
proxy_set_header Host $http_host;
to the /zx location

Thanks