### PR TITLE
Set proxy_max_temp_file_size to 8M for Drive requests

### DIFF
--- a/conf/nginx/nginx.conf.web.http.default.template
+++ b/conf/nginx/nginx.conf.web.http.default.template
@@ -177,6 +177,65 @@ server
         proxy_pass ${web.upstream.zx};
     }
 
+    location ~* /service/extension/drive/(.*)/(.*)$ 
+		{
+        # Begin stray redirect hack
+        #
+        # In some cases, we may get a stray redirect out of the mailhost,
+        # which attempts to send us to $host:$mailhostport, where:
+        #
+        # $host is the host portion (excluding port) of the proxy URL
+        # $mailhostport is the zimbraMailPort as applies to the mailhost
+        #   server being redirected to
+        #
+        # This is the case when one mailhost in the upstream cluster is
+        # trying to redirect to another mailhost in the same cluster
+        # In this case, we need to trap and fudge this location header
+        #
+        # NOTE that this will only work in the cases where each mailhost
+        # within the cluster has the same mailhostport (Limitation)
+        #
+        set $mailhostport ${web.http.uport};   # replace this with *the* mailhost port
+        set $relhost $host;
+
+        if ($mailhostport != 80) {   # standard HTTP port, do not replace
+            set $relhost $host:$mailhostport;
+        }
+
+        # End stray redirect hack
+
+        # Proxy to Zimbra Upstream servers, with large buffers
+        proxy_pass          ${web.upstream.target};
+        proxy_read_timeout  ${web.upstream.noop.timeout};
+
+        # For audit
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # For Virtual Hosting
+        set $virtual_host $http_host;
+        if ($virtual_host = '') {
+            set $virtual_host $server_name:$server_port;
+        }
+        proxy_set_header Host            $virtual_host;
+
+        # Location header fudging
+        # Because NGINX SSL speaks plain HTTP to upstream, therefore any
+        # redirects to http:// coming from the upstream need to be fudged
+        # to https://
+        #
+        proxy_redirect http://$http_host/ https://$http_host/;
+
+        # Fudge inter-mailbox redirects (kludge)
+        proxy_redirect http://$relhost/ https://$http_host/;
+        
+        # We need to set a lower temporary filesize to force nginx to ask data more
+        # frequently to jetty.
+        # 8M -> lower limit of ~140kb/sec
+        # 4M -> lower limit of ~70kb/sec
+        # Adjust it according to your users' needs.
+        proxy_max_temp_file_size 8M;
+    }
+
     # For NoOpRequest
     location ^~ /service/soap/NoOpRequest {
     

--- a/conf/nginx/nginx.conf.web.http.template
+++ b/conf/nginx/nginx.conf.web.http.template
@@ -178,6 +178,65 @@ server
         proxy_pass ${web.upstream.zx};
     }
 
+    location ~* /service/extension/drive/(.*)/(.*)$ 
+		{
+        # Begin stray redirect hack
+        #
+        # In some cases, we may get a stray redirect out of the mailhost,
+        # which attempts to send us to $host:$mailhostport, where:
+        #
+        # $host is the host portion (excluding port) of the proxy URL
+        # $mailhostport is the zimbraMailPort as applies to the mailhost
+        #   server being redirected to
+        #
+        # This is the case when one mailhost in the upstream cluster is
+        # trying to redirect to another mailhost in the same cluster
+        # In this case, we need to trap and fudge this location header
+        #
+        # NOTE that this will only work in the cases where each mailhost
+        # within the cluster has the same mailhostport (Limitation)
+        #
+        set $mailhostport ${web.http.uport};   # replace this with *the* mailhost port
+        set $relhost $host;
+
+        if ($mailhostport != 80) {   # standard HTTP port, do not replace
+            set $relhost $host:$mailhostport;
+        }
+
+        # End stray redirect hack
+
+        # Proxy to Zimbra Upstream servers, with large buffers
+        proxy_pass          ${web.upstream.target};
+        proxy_read_timeout  ${web.upstream.noop.timeout};
+
+        # For audit
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # For Virtual Hosting
+        set $virtual_host $http_host;
+        if ($virtual_host = '') {
+            set $virtual_host $server_name:$server_port;
+        }
+        proxy_set_header Host            $virtual_host;
+
+        # Location header fudging
+        # Because NGINX SSL speaks plain HTTP to upstream, therefore any
+        # redirects to http:// coming from the upstream need to be fudged
+        # to https://
+        #
+        proxy_redirect http://$http_host/ https://$http_host/;
+
+        # Fudge inter-mailbox redirects (kludge)
+        proxy_redirect http://$relhost/ https://$http_host/;
+        
+        # We need to set a lower temporary filesize to force nginx to ask data more
+        # frequently to jetty.
+        # 8M -> lower limit of ~140kb/sec
+        # 4M -> lower limit of ~70kb/sec
+        # Adjust it according to your users' needs.
+        proxy_max_temp_file_size 8M;
+    }
+
     # For NoOpRequest
     location ^~ /service/soap/NoOpRequest {
 

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -264,6 +264,65 @@ server
         proxy_pass ${web.upstream.zx};
     }
 
+    location ~* /service/extension/drive/(.*)/(.*)$ 
+		{
+        # Begin stray redirect hack
+        #
+        # In some cases, we may get a stray redirect out of the mailhost,
+        # which attempts to send us to $host:$mailhostport, where:
+        #
+        # $host is the host portion (excluding port) of the proxy URL
+        # $mailhostport is the zimbraMailPort as applies to the mailhost
+        #   server being redirected to
+        #
+        # This is the case when one mailhost in the upstream cluster is
+        # trying to redirect to another mailhost in the same cluster
+        # In this case, we need to trap and fudge this location header
+        #
+        # NOTE that this will only work in the cases where each mailhost
+        # within the cluster has the same mailhostport (Limitation)
+        #
+        set $mailhostport ${web.http.uport};   # replace this with *the* mailhost port
+        set $relhost $host;
+
+        if ($mailhostport != 80) {   # standard HTTP port, do not replace
+            set $relhost $host:$mailhostport;
+        }
+
+        # End stray redirect hack
+
+        # Proxy to Zimbra Upstream servers, with large buffers
+        proxy_pass          ${web.upstream.target};
+        proxy_read_timeout  ${web.upstream.noop.timeout};
+
+        # For audit
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # For Virtual Hosting
+        set $virtual_host $http_host;
+        if ($virtual_host = '') {
+            set $virtual_host $server_name:$server_port;
+        }
+        proxy_set_header Host            $virtual_host;
+
+        # Location header fudging
+        # Because NGINX SSL speaks plain HTTP to upstream, therefore any
+        # redirects to http:// coming from the upstream need to be fudged
+        # to https://
+        #
+        proxy_redirect http://$http_host/ https://$http_host/;
+
+        # Fudge inter-mailbox redirects (kludge)
+        proxy_redirect http://$relhost/ https://$http_host/;
+        
+        # We need to set a lower temporary filesize to force nginx to ask data more
+        # frequently to jetty.
+        # 8M -> lower limit of ~140kb/sec
+        # 4M -> lower limit of ~70kb/sec
+        # Adjust it according to your users' needs.
+        proxy_max_temp_file_size 8M;
+    }
+
     # For NoOpRequest
     location ^~ /service/soap/NoOpRequest {
 

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -219,6 +219,65 @@ server
         proxy_pass ${web.upstream.zx};
     }
 
+    location ~* /service/extension/drive/(.*)/(.*)$ 
+		{
+        # Begin stray redirect hack
+        #
+        # In some cases, we may get a stray redirect out of the mailhost,
+        # which attempts to send us to $host:$mailhostport, where:
+        #
+        # $host is the host portion (excluding port) of the proxy URL
+        # $mailhostport is the zimbraMailPort as applies to the mailhost
+        #   server being redirected to
+        #
+        # This is the case when one mailhost in the upstream cluster is
+        # trying to redirect to another mailhost in the same cluster
+        # In this case, we need to trap and fudge this location header
+        #
+        # NOTE that this will only work in the cases where each mailhost
+        # within the cluster has the same mailhostport (Limitation)
+        #
+        set $mailhostport ${web.http.uport};   # replace this with *the* mailhost port
+        set $relhost $host;
+
+        if ($mailhostport != 80) {   # standard HTTP port, do not replace
+            set $relhost $host:$mailhostport;
+        }
+
+        # End stray redirect hack
+
+        # Proxy to Zimbra Upstream servers, with large buffers
+        proxy_pass          ${web.upstream.target};
+        proxy_read_timeout  ${web.upstream.noop.timeout};
+
+        # For audit
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # For Virtual Hosting
+        set $virtual_host $http_host;
+        if ($virtual_host = '') {
+            set $virtual_host $server_name:$server_port;
+        }
+        proxy_set_header Host            $virtual_host;
+
+        # Location header fudging
+        # Because NGINX SSL speaks plain HTTP to upstream, therefore any
+        # redirects to http:// coming from the upstream need to be fudged
+        # to https://
+        #
+        proxy_redirect http://$http_host/ https://$http_host/;
+
+        # Fudge inter-mailbox redirects (kludge)
+        proxy_redirect http://$relhost/ https://$http_host/;
+        
+        # We need to set a lower temporary filesize to force nginx to ask data more
+        # frequently to jetty.
+        # 8M -> lower limit of ~140kb/sec
+        # 4M -> lower limit of ~70kb/sec
+        # Adjust it according to your users' needs.
+        proxy_max_temp_file_size 8M;
+    }
+
     # For NoOpRequest
     location ^~ /service/soap/NoOpRequest {
 


### PR DESCRIPTION
A new, specific, location for Drive has been implemented in NGINX's config templates to force the latter to request data more frequently from upstream.