### PR TITLE
ZBUG-2099: Enable http2 at web.https confs

### DIFF
--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -29,9 +29,9 @@ ${web.strict.servername}}
 
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${web.https.port} ipv6only=off ssl;
-    ${core.ipv4only.enabled}listen                ${web.https.port} ssl;
-    ${core.ipv6only.enabled}listen                [::]:${web.https.port} ssl;
+    ${core.ipboth.enabled}listen                  [::]:${web.https.port} ipv6only=off ssl http2;
+    ${core.ipv4only.enabled}listen                ${web.https.port} ssl http2;
+    ${core.ipv6only.enabled}listen                [::]:${web.https.port} ssl http2;
 
     ${web.add.headers.default}
     server_name             ${web.server_name.default}; # add aliases and perhaps public

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -4,9 +4,9 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${web.https.port} ipv6only=off ssl;
-    ${core.ipv4only.enabled}listen                  ${vip}${web.https.port} ssl;
-    ${core.ipv6only.enabled}listen                  ${vip}${web.https.port} ssl;
+    ${core.ipboth.enabled}listen                  ${vip}${web.https.port} ipv6only=off ssl http2;
+    ${core.ipv4only.enabled}listen                  ${vip}${web.https.port} ssl http2;
+    ${core.ipv6only.enabled}listen                  ${vip}${web.https.port} ssl http2;
     ${web.add.headers.vhost}
     client_max_body_size    0;
     ssl_protocols           ${web.ssl.protocols};


### PR DESCRIPTION
**Requirement:**
- Client requested for a support of http2 protocol in nginx.

**Changes:**
- Enabled the flag that can open up the feature.
- Module addition was already done as part of the last PR https://github.com/Zimbra/packages/pull/119

**Testing:**
- Tested the same with firefox browser, worked well.
