### PR TITLE
ZRFE-29:Dual stack IPv4 + IPv6, Multiple domain & vhost

### DIFF
--- a/conf/nginx/nginx.conf.mail.imap.default.template
+++ b/conf/nginx/nginx.conf.mail.imap.default.template
@@ -2,7 +2,7 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${mail.imap.port} ipv6only=off;
+    ${core.ipboth.enabled}listen                  [::]:${mail.imap.port};
     ${core.ipv4only.enabled}listen                ${mail.imap.port};
     ${core.ipv6only.enabled}listen                [::]:${mail.imap.port};
     ${web.ssl.dhparam.enabled}ssl_dhparam         ${web.ssl.dhparam.file};

--- a/conf/nginx/nginx.conf.mail.imap.template
+++ b/conf/nginx/nginx.conf.mail.imap.template
@@ -4,7 +4,7 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${mail.imap.port} ipv6only=off;
+    ${core.ipboth.enabled}listen                  ${vip}${mail.imap.port};
     ${core.ipv4only.enabled}listen                  ${vip}${mail.imap.port};
     ${core.ipv6only.enabled}listen                  ${vip}${mail.imap.port};
     protocol                imap;

--- a/conf/nginx/nginx.conf.mail.imaps.default.template
+++ b/conf/nginx/nginx.conf.mail.imaps.default.template
@@ -2,7 +2,7 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${mail.imaps.port} ipv6only=off ssl;
+    ${core.ipboth.enabled}listen                  [::]:${mail.imaps.port} ssl;
     ${core.ipv4only.enabled}listen                ${mail.imaps.port} ssl;
     ${core.ipv6only.enabled}listen                [::]:${mail.imaps.port} ssl;
     ${web.ssl.dhparam.enabled}ssl_dhparam         ${web.ssl.dhparam.file};

--- a/conf/nginx/nginx.conf.mail.imaps.template
+++ b/conf/nginx/nginx.conf.mail.imaps.template
@@ -4,7 +4,7 @@
 server
 {
     server_name         ${vhn};
-    ${core.ipboth.enabled}listen              ${vip}${mail.imaps.port} ipv6only=off ssl;
+    ${core.ipboth.enabled}listen              ${vip}${mail.imaps.port} ssl;
     ${core.ipv4only.enabled}listen            ${vip}${mail.imaps.port} ssl;
     ${core.ipv6only.enabled}listen            ${vip}${mail.imaps.port} ssl;
     protocol            imap;

--- a/conf/nginx/nginx.conf.mail.pop3.default.template
+++ b/conf/nginx/nginx.conf.mail.pop3.default.template
@@ -2,7 +2,7 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${mail.pop3.port} ipv6only=off;
+    ${core.ipboth.enabled}listen                  [::]:${mail.pop3.port};
     ${core.ipv4only.enabled}listen                ${mail.pop3.port};
     ${core.ipv6only.enabled}listen                [::]:${mail.pop3.port};
     ${web.ssl.dhparam.enabled}ssl_dhparam         ${web.ssl.dhparam.file};

--- a/conf/nginx/nginx.conf.mail.pop3.template
+++ b/conf/nginx/nginx.conf.mail.pop3.template
@@ -4,7 +4,7 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${mail.pop3.port} ipv6only=off;
+    ${core.ipboth.enabled}listen                  ${vip}${mail.pop3.port};
     ${core.ipv4only.enabled}listen                  ${vip}${mail.pop3.port};
     ${core.ipv6only.enabled}listen                  ${vip}${mail.pop3.port};
     protocol                pop3;

--- a/conf/nginx/nginx.conf.mail.pop3s.default.template
+++ b/conf/nginx/nginx.conf.mail.pop3s.default.template
@@ -2,7 +2,7 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen              [::]:${mail.pop3s.port} ipv6only=off ssl;
+    ${core.ipboth.enabled}listen              [::]:${mail.pop3s.port} ssl;
     ${core.ipv4only.enabled}listen            ${mail.pop3s.port} ssl;
     ${core.ipv6only.enabled}listen            [::]:${mail.pop3s.port} ssl;
     ${web.ssl.dhparam.enabled}ssl_dhparam     ${web.ssl.dhparam.file};

--- a/conf/nginx/nginx.conf.mail.pop3s.template
+++ b/conf/nginx/nginx.conf.mail.pop3s.template
@@ -4,7 +4,7 @@
 server
 {
     server_name         ${vhn};
-    ${core.ipboth.enabled}listen              ${vip}${mail.pop3s.port} ipv6only=off ssl;
+    ${core.ipboth.enabled}listen              ${vip}${mail.pop3s.port} ssl;
     ${core.ipv4only.enabled}listen            ${vip}${mail.pop3s.port} ssl;
     ${core.ipv6only.enabled}listen            ${vip}${mail.pop3s.port} ssl;
     protocol            pop3;

--- a/conf/nginx/nginx.conf.web.admin.default.template
+++ b/conf/nginx/nginx.conf.web.admin.default.template
@@ -2,9 +2,10 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${web.admin.port} default ipv6only=off ssl;
-    ${core.ipv4only.enabled}listen                ${web.admin.port} default ssl;
-    ${core.ipv6only.enabled}listen                [::]:${web.admin.port} default ssl;
+    ${core.ipboth.enabled}listen                  ${web.admin.port} default_server ssl;
+    ${core.ipboth.enabled}listen                  [::]:${web.admin.port} default_server ssl;
+    ${core.ipv4only.enabled}listen                ${web.admin.port} default_server ssl;
+    ${core.ipv6only.enabled}listen                [::]:${web.admin.port} default_server ssl;
     ${web.add.headers.default}
     client_max_body_size    0;
     ssl_protocols           ${web.ssl.protocols};

--- a/conf/nginx/nginx.conf.web.admin.template
+++ b/conf/nginx/nginx.conf.web.admin.template
@@ -4,7 +4,7 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                    ${vip}${web.admin.port} ipv6only=off ssl;
+    ${core.ipboth.enabled}listen                    ${vip}${web.admin.port} ssl;
     ${core.ipv4only.enabled}listen                  ${vip}${web.admin.port} ssl;
     ${core.ipv6only.enabled}listen                  ${vip}${web.admin.port} ssl;
     ${web.add.headers.vhost}

--- a/conf/nginx/nginx.conf.web.http.default.template
+++ b/conf/nginx/nginx.conf.web.http.default.template
@@ -2,7 +2,7 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen    [::]:${web.http.port} default ipv6only=off;
+    ${core.ipboth.enabled}listen    [::]:${web.http.port} default;
     ${core.ipv4only.enabled}listen    ${web.http.port} default;
     ${core.ipv6only.enabled}listen    [::]:${web.http.port} default;
     server_name             ${web.server_name.default}.default;

--- a/conf/nginx/nginx.conf.web.http.template
+++ b/conf/nginx/nginx.conf.web.http.template
@@ -4,7 +4,7 @@
 server
 {
     server_name         ${vhn};
-    ${core.ipboth.enabled}listen            ${vip}${web.http.port} ipv6only=off;
+    ${core.ipboth.enabled}listen            ${vip}${web.http.port};
     ${core.ipv4only.enabled}listen            ${vip}${web.http.port};
     ${core.ipv6only.enabled}listen            ${vip}${web.http.port};
     client_max_body_size 0;

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -29,9 +29,10 @@ ${web.strict.servername}}
 
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${web.https.port} ipv6only=off ssl http2;
-    ${core.ipv4only.enabled}listen                ${web.https.port} ssl http2;
-    ${core.ipv6only.enabled}listen                [::]:${web.https.port} ssl http2;
+    ${core.ipboth.enabled}listen                  ${web.https.port} default_server ssl http2;
+    ${core.ipboth.enabled}listen                  [::]:${web.https.port} default_server ssl http2;
+    ${core.ipv4only.enabled}listen                ${web.https.port} default_server ssl http2;
+    ${core.ipv6only.enabled}listen                [::]:${web.https.port} default_server ssl http2;
 
     ${web.add.headers.default}
     server_name             ${web.server_name.default}; # add aliases and perhaps public

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -4,7 +4,7 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${web.https.port} ipv6only=off ssl http2;
+    ${core.ipboth.enabled}listen                  ${vip}${web.https.port} ssl http2;
     ${core.ipv4only.enabled}listen                  ${vip}${web.https.port} ssl http2;
     ${core.ipv6only.enabled}listen                  ${vip}${web.https.port} ssl http2;
     ${web.add.headers.vhost}

--- a/conf/nginx/nginx.conf.web.sso.default.template
+++ b/conf/nginx/nginx.conf.web.sso.default.template
@@ -1,6 +1,6 @@
 #client cert auth
 server {
-    ${core.ipboth.enabled}listen                  [::]:${web.sso.certauth.port} default ipv6only=off ssl;
+    ${core.ipboth.enabled}listen                  [::]:${web.sso.certauth.port} default ssl;
     ${core.ipv4only.enabled}listen                ${web.sso.certauth.port} default ssl;
     ${core.ipv6only.enabled}listen                [::]:${web.sso.certauth.port} default ssl;
     ${web.add.headers.default}

--- a/conf/nginx/nginx.conf.web.sso.template
+++ b/conf/nginx/nginx.conf.web.sso.template
@@ -3,7 +3,7 @@
 #client cert auth
 server {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${web.sso.certauth.port} ipv6only=off ssl;
+    ${core.ipboth.enabled}listen                  ${vip}${web.sso.certauth.port} ssl;
     ${core.ipv4only.enabled}listen                  ${vip}${web.sso.certauth.port} ssl;
     ${core.ipv6only.enabled}listen                  ${vip}${web.sso.certauth.port} ssl;
     ${web.add.headers.vhost}


### PR DESCRIPTION
**Enhancement** : Support Dual stack IPv4 + IPv6, Multiple domain & vhost for Zimbra

**Problem:**
After adding multiple `zimbraVirtualIPAddress` nginx failed to start.
zmprov md zimbra.redpill-linpro.com +zimbraVirtualIPAddress "2a02:c0:200:c000::228"

We now have:

zmprov gd zimbra.redpill-linpro.com zimbraVirtualHostname zimbraVirtualIPAddress
name zimbra.redpill-linpro.com
zimbraVirtualHostname: zimbra.redpill-linpro.com
zimbraVirtualIPAddress: 87.238.49.227
zimbraVirtualIPAddress: 2a02:c0:200:c000::228

But when restarting proxy, I now get:

zimbra@nerva:~$ zmproxyctl restart
Stopping proxy...proxy is not running.
Starting proxy...failed.
nginx start failed. reason: The configurations of zimbraVirtualHostname and zimbraVirtualIPAddress are mismatched

**Fix:**
As per comments in https://bugzilla.zimbra.com/show_bug.cgi?id=107587, need to remove `ipv6only=off` from nginx templates.