### PR TITLE
Proxified mail services not working anymore with ipv4 in ipboth mode: fix regression

### DIFF
--- a/conf/nginx/nginx.conf.mail.imap.default.template
+++ b/conf/nginx/nginx.conf.mail.imap.default.template
@@ -3,6 +3,7 @@
 server
 {
     ${core.ipboth.enabled}listen                  [::]:${mail.imap.port};
+    ${core.ipboth.enabled}listen                  ${mail.imap.port};
     ${core.ipv4only.enabled}listen                ${mail.imap.port};
     ${core.ipv6only.enabled}listen                [::]:${mail.imap.port};
     ${web.ssl.dhparam.enabled}ssl_dhparam         ${web.ssl.dhparam.file};

--- a/conf/nginx/nginx.conf.mail.imaps.default.template
+++ b/conf/nginx/nginx.conf.mail.imaps.default.template
@@ -3,6 +3,7 @@
 server
 {
     ${core.ipboth.enabled}listen                  [::]:${mail.imaps.port} ssl;
+    ${core.ipboth.enabled}listen                  ${mail.imaps.port} ssl;
     ${core.ipv4only.enabled}listen                ${mail.imaps.port} ssl;
     ${core.ipv6only.enabled}listen                [::]:${mail.imaps.port} ssl;
     ${web.ssl.dhparam.enabled}ssl_dhparam         ${web.ssl.dhparam.file};

--- a/conf/nginx/nginx.conf.mail.pop3.default.template
+++ b/conf/nginx/nginx.conf.mail.pop3.default.template
@@ -3,6 +3,7 @@
 server
 {
     ${core.ipboth.enabled}listen                  [::]:${mail.pop3.port};
+    ${core.ipboth.enabled}listen                  ${mail.pop3.port};
     ${core.ipv4only.enabled}listen                ${mail.pop3.port};
     ${core.ipv6only.enabled}listen                [::]:${mail.pop3.port};
     ${web.ssl.dhparam.enabled}ssl_dhparam         ${web.ssl.dhparam.file};

--- a/conf/nginx/nginx.conf.mail.pop3s.default.template
+++ b/conf/nginx/nginx.conf.mail.pop3s.default.template
@@ -3,6 +3,7 @@
 server
 {
     ${core.ipboth.enabled}listen              [::]:${mail.pop3s.port} ssl;
+    ${core.ipboth.enabled}listen              ${mail.pop3s.port} ssl;
     ${core.ipv4only.enabled}listen            ${mail.pop3s.port} ssl;
     ${core.ipv6only.enabled}listen            [::]:${mail.pop3s.port} ssl;
     ${web.ssl.dhparam.enabled}ssl_dhparam     ${web.ssl.dhparam.file};

--- a/conf/nginx/nginx.conf.web.http.default.template
+++ b/conf/nginx/nginx.conf.web.http.default.template
@@ -3,6 +3,7 @@
 server
 {
     ${core.ipboth.enabled}listen    [::]:${web.http.port} default;
+    ${core.ipboth.enabled}listen    ${web.http.port} default;
     ${core.ipv4only.enabled}listen    ${web.http.port} default;
     ${core.ipv6only.enabled}listen    [::]:${web.http.port} default;
     server_name             ${web.server_name.default}.default;

--- a/conf/nginx/nginx.conf.web.sso.default.template
+++ b/conf/nginx/nginx.conf.web.sso.default.template
@@ -1,6 +1,7 @@
 #client cert auth
 server {
     ${core.ipboth.enabled}listen                  [::]:${web.sso.certauth.port} default ssl;
+    ${core.ipboth.enabled}listen                  ${web.sso.certauth.port} default ssl;
     ${core.ipv4only.enabled}listen                ${web.sso.certauth.port} default ssl;
     ${core.ipv6only.enabled}listen                [::]:${web.sso.certauth.port} default ssl;
     ${web.add.headers.default}


### PR DESCRIPTION
Proxified mail services are not working anymore with IPv4 (only IPv6) in `ipboth` mode on 8.8.15 since patch P20.

Without `ipv6only=off` in Nginx conf, we should now have two listen lines for `ipboth` mode (as you actually did in `nginx.conf.web.admin.default.template`).

Regression introduced in ZRFE-29 / ZCS-10278 / d95de5d300b2784a3c7617f7f0c5c70510c0c353 / PR #21