### PR TITLE
ZCS-10581: adding upstream for onlyoffice zdocument path

### DIFF
--- a/conf/nginx/nginx.conf.docs.common.template
+++ b/conf/nginx/nginx.conf.docs.common.template
@@ -1,20 +1,19 @@
 !{explode server(docs)}
 
-# static files
-location ^~ /docs/${server_id}/loleaflet {
-    rewrite /docs/${server_id}/(.*) /$1 break;
-    proxy_pass http://docs-${server_id};
-    proxy_set_header Host $http_host;
-    proxy_http_version 1.1;
-}
+location ^~ /zdocument
+{
+        # convert proxied connection to upgrade to support WebSockets
+        proxy_set_header Upgrade $http_upgrade;
 
-# websockets, download, presentation and image upload
-location ^~ /docs/${server_id}/lool {
-    rewrite  ^  $request_uri;            # get original URI
-    rewrite /docs/${server_id}/(.*) /$1 break;
-    proxy_pass http://docs-${server_id}$uri;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $http_host;
-    proxy_http_version 1.1;
+        # set the host header
+        proxy_set_header X-Forwarded-Host $http_host/zdocument;
+
+        # maintain IP of the client sending requests in headers
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # change in coming requests to 1.1 to support WebSockets
+        proxy_http_version 1.1;
+
+        # proxy to Doc Server Upstream
+        proxy_pass https://docs-${server_id}/;
 }

--- a/conf/nginx/nginx.conf.docs.upstream.template
+++ b/conf/nginx/nginx.conf.docs.upstream.template
@@ -1,5 +1,5 @@
 !{explode server(docs)}
 upstream docs-${server_id}
 {
-  server ${server_hostname}:9980;
+  server ${server_hostname}:443;
 }


### PR DESCRIPTION
Issue
On editing document onlyoffice server is visible in the view source for access api.js to load onlyoffice editing view

Fix
Hide the api.js access by adding upstream for path /zdocument as done in zimbra cloud

Tested
Onlyoffice server isn't visible while editing document and document edit/save works fine as expected

https://github.com/Zimbra/zm-doc-server-ext/pull/2
