### PR TITLE
Add the new onlyoffice config and use it

### DIFF
--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -600,6 +600,6 @@ server
         # for custom error pages, internal use only
         internal;
     }
-
+	include					${core.includes}/${core.cprefix}.onlyoffice.common;
     include                 ${core.includes}/${core.cprefix}.docs.common;
 }

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -600,6 +600,6 @@ server
         # for custom error pages, internal use only
         internal;
     }
-	include					${core.includes}/${core.cprefix}.onlyoffice.common;
+    include                 ${core.includes}/${core.cprefix}.onlyoffice.common;
     include                 ${core.includes}/${core.cprefix}.docs.common;
 }

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -556,7 +556,7 @@ server
         # for custom error pages, internal use only
         internal;
     }
-	include					${core.includes}/${core.cprefix}.onlyoffice.common;
+    include                 ${core.includes}/${core.cprefix}.onlyoffice.common;
     include                 ${core.includes}/${core.cprefix}.docs.common;
 }
 

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -1,5 +1,5 @@
-!{explode domain(vhn)}
 # HTTPS Proxy Configuration
+!{explode domain(vhn)}
 #
 server
 {
@@ -556,7 +556,7 @@ server
         # for custom error pages, internal use only
         internal;
     }
-
+	include					${core.includes}/${core.cprefix}.onlyoffice.common;
     include                 ${core.includes}/${core.cprefix}.docs.common;
 }
 

--- a/conf/nginx/nginx.conf.web.template
+++ b/conf/nginx/nginx.conf.web.template
@@ -85,7 +85,7 @@ http
         ${web.admin.upstream.:servers}
         zmauth_admin;
     }
-
+	include					${core.includes}/${core.cprefix}.onlyoffice.upstream;
     include                 ${core.includes}/${core.cprefix}.docs.upstream;
 
     #  Define the collection of upstream HTTP EWS servers to which we will

--- a/conf/nginx/nginx.conf.web.template
+++ b/conf/nginx/nginx.conf.web.template
@@ -85,7 +85,7 @@ http
         ${web.admin.upstream.:servers}
         zmauth_admin;
     }
-	include					${core.includes}/${core.cprefix}.onlyoffice.upstream;
+    include                 ${core.includes}/${core.cprefix}.onlyoffice.upstream;
     include                 ${core.includes}/${core.cprefix}.docs.upstream;
 
     #  Define the collection of upstream HTTP EWS servers to which we will


### PR DESCRIPTION
New onlyoffice config has been added. These changes are required so that new config can be used.

PR reference : https://github.com/Zimbra/zm-nginx-conf/pull/25

