### PR TITLE
feature/ZCS-10533 : Fixing template

### DIFF
--- a/conf/nginx/nginx.conf.web.http.default.template
+++ b/conf/nginx/nginx.conf.web.http.default.template
@@ -483,5 +483,6 @@ server
         internal;
     }
 
+    include                 ${core.includes}/${core.cprefix}.onlyoffice.common;
     include                 ${core.includes}/${core.cprefix}.docs.common;
 }

--- a/conf/nginx/nginx.conf.web.http.template
+++ b/conf/nginx/nginx.conf.web.http.template
@@ -484,6 +484,7 @@ server
         internal;
     }
 
+    include                 ${core.includes}/${core.cprefix}.onlyoffice.common;
     include                 ${core.includes}/${core.cprefix}.docs.common;
 }
 

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -1,5 +1,5 @@
-# HTTPS Proxy Configuration
 !{explode domain(vhn)}
+# HTTPS Proxy Configuration
 #
 server
 {


### PR DESCRIPTION
!{explode domain(vhn)} needs to be the first line in the template.
It gives an error on `zmproxyctl restart`

> zimbra@zqa-410:~$ zmproxyctl restart
> Stopping proxy...proxy is not running.
> Starting proxy...nginx: [emerg] unknown directive "!" in /opt/zimbra/conf/nginx/includes/nginx.conf.web.https:2
> failed.