### PR TITLE
Feature/ZCS 10618

### DIFF
--- a/conf/nginx/nginx.conf.onlyoffice.common.template
+++ b/conf/nginx/nginx.conf.onlyoffice.common.template
@@ -1,4 +1,3 @@
-!{explode server(onlyoffice)}
 # Allow internal service only from 127.0.0.1
 location ~* ^(/zdocument)\/([^\/]+)?\/(info|internal)(\/.*)$ {
   allow 127.0.0.1;

--- a/conf/nginx/nginx.conf.onlyoffice.common.template
+++ b/conf/nginx/nginx.conf.onlyoffice.common.template
@@ -1,48 +1,62 @@
 !{explode server(onlyoffice)}
 # Allow internal service only from 127.0.0.1
-location ~* ^(/zdocument)?\/(info|internal)(\/.*)$ {
+location ~* ^(/zdocument)\/([^\/]+)?\/(info|internal)(\/.*)$ {
   allow 127.0.0.1;
   deny all;
-  proxy_pass https://docservice/$2$3;
+  set $rel_loc $2;
+  proxy_pass https://docservice_$rel_loc/$3$4;
+
+  proxy_set_header Host $http_host;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $proxy_connection;
+  proxy_set_header X-Forwarded-Host $the_host/zdocument/$2;
+  proxy_set_header X-Forwarded-Proto $the_scheme;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 }
 
-location /zdocument
+
+location ~ ^(/zdocument)\/([^\/]+)?(\/doc\/.*) {
+  set $rel_loc $2;
+  proxy_pass https://docservice_$rel_loc$3;
+  proxy_http_version 1.1;
+
+  proxy_set_header Host $http_host;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $proxy_connection;
+  proxy_set_header X-Forwarded-Host $the_host/zdocument/$2;
+  proxy_set_header X-Forwarded-Proto $the_scheme;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+
+location ~ ^(/zdocument)\/([^\/]+)?(\/spellchecker)(\/.*)$ {
+  set $rel_loc $2;
+  proxy_pass https://spellchecker_$rel_loc$4;
+  proxy_http_version 1.1;
+  proxy_set_header Host $http_host;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $proxy_connection;
+  proxy_set_header X-Forwarded-Host $the_host/zdocument/$2;
+  proxy_set_header X-Forwarded-Proto $the_scheme;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+
+location ~ ^(\/zdocument)\/([^\/]+)(\/.*)
 {
-  rewrite /zdocument/(.*) /$1  break;
+  set $rel_loc $2;
   # proxy to Doc Server Upstream
-  proxy_pass https://docservice;
+  proxy_pass https://docservice_$rel_loc;
 
   proxy_set_header Host $http_host;
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection $proxy_connection;
-  proxy_set_header X-Forwarded-Host $the_host/zdocument;
+  proxy_set_header X-Forwarded-Host $the_host/zdocument/$2;
   proxy_set_header X-Forwarded-Proto $the_scheme;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+  rewrite ^(\/zdocument)(\/[^\/]+)(\/.*) $3  break;
 }
-
-location ~ ^(/zdocument)?(\/doc\/.*) {
-  proxy_pass https://docservice$2;
-  proxy_http_version 1.1;
-
-  proxy_set_header Host $http_host;
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header Connection $proxy_connection;
-  proxy_set_header X-Forwarded-Host $the_host/zdocument;
-  proxy_set_header X-Forwarded-Proto $the_scheme;
-  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
-location ~ (/zdocument)?(\/spellchecker)(\/.*)$ {
-  proxy_pass https://spellchecker$3;
-  proxy_http_version 1.1;
-  proxy_set_header Host $http_host;
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header Connection $proxy_connection;
-  proxy_set_header X-Forwarded-Host $the_host/zdocument;
-  proxy_set_header X-Forwarded-Proto $the_scheme;
-  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-}
-
 
 types {
     text/html                             html htm shtml;

--- a/conf/nginx/nginx.conf.onlyoffice.upstream.template
+++ b/conf/nginx/nginx.conf.onlyoffice.upstream.template
@@ -1,4 +1,3 @@
-!{explode server(onlyoffice)}
 
 ${web.upstream.onlyoffice.docservice}
 

--- a/conf/nginx/nginx.conf.onlyoffice.upstream.template
+++ b/conf/nginx/nginx.conf.onlyoffice.upstream.template
@@ -1,13 +1,8 @@
 !{explode server(onlyoffice)}
-upstream docservice {
-    ${web.upstream.onlyoffice.docservice.:servers}
-    zmauth;
-}
 
-upstream spellchecker {  
-    ${web.upstream.onlyoffice.spellchecker.:servers}
-    zmauth;
-}
+${web.upstream.onlyoffice.docservice}
+
+${web.upstream.onlyoffice.spellchecker}
 
 map $http_host $this_host {
     "" $host;

--- a/conf/nginx/nginx.conf.onlyoffice.upstream.template
+++ b/conf/nginx/nginx.conf.onlyoffice.upstream.template
@@ -1,10 +1,12 @@
 !{explode server(onlyoffice)}
 upstream docservice {
-	server ${server_hostname}:7084 max_fails=0 fail_timeout=0s;
+    ${web.upstream.onlyoffice.docservice.:servers}
+    zmauth;
 }
 
 upstream spellchecker {  
-	server ${server_hostname}:7085;
+    ${web.upstream.onlyoffice.spellchecker.:servers}
+    zmauth;
 }
 
 map $http_host $this_host {


### PR DESCRIPTION
**Problem**
1. Generate the onlyoffice nginx config to redirect the onlyoffice requests ( url which starts with /zdocument) to the particular onlyoffice server for : 
 1.1 Single Deployment of onlyoffice (Onlyoffice on a single mailbox server) or One onlyoffice on each mailbox server.
 1.2 Single Onlyoffice Deployment on a different server. It is defined by setting `zimbraDocumentEditingHost`

2. Generate the nginx config while using `zmproxyctl` for both type of deployments as mentioned in 1

Solution:
Added 2 new keys or placeholders ( web.upstream.onlyoffice.docservice , web.upstream.onlyoffice.spellchecker). Added new classes to generate the upstream blocks for docservice and spellchecker.

Tests: 
Added the templates. Installed onlyoffice based on the conditions in Problem 1.
executed `zmproxyctl restart`. Checked the upstream blocks generated. They are genearted as `docservice_hash of zimbraId of the server or servers`

Related PR : https://github.com/Zimbra/zm-mailbox/pull/1153
https://github.com/Zimbra/zm-doc-server-ext/pull/4