### PR TITLE
ZBUG-2502: Allow zimbraIPModeBoth

### DIFF
--- a/conf/nginx/nginx.conf.mail.imap.default.template
+++ b/conf/nginx/nginx.conf.mail.imap.default.template
@@ -2,7 +2,8 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${mail.imap.port} ipv6only=off;
+    ${core.ipboth.enabled}listen                  ${mail.imap.port};
+    ${core.ipboth.enabled}listen                  [::]:${mail.imap.port};
     ${core.ipv4only.enabled}listen                ${mail.imap.port};
     ${core.ipv6only.enabled}listen                [::]:${mail.imap.port};
     ${web.ssl.dhparam.enabled}ssl_dhparam         ${web.ssl.dhparam.file};

--- a/conf/nginx/nginx.conf.mail.imap.template
+++ b/conf/nginx/nginx.conf.mail.imap.template
@@ -4,8 +4,7 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${mail.imap.port};
-    ${core.ipboth.enabled}listen                  [::]:${vip}${mail.imap.port};
+    ${core.ipboth.enabled}listen                    ${vip}${mail.imap.port};
     ${core.ipv4only.enabled}listen                  ${vip}${mail.imap.port};
     ${core.ipv6only.enabled}listen                  ${vip}${mail.imap.port};
     protocol                imap;

--- a/conf/nginx/nginx.conf.mail.imap.template
+++ b/conf/nginx/nginx.conf.mail.imap.template
@@ -4,7 +4,8 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${mail.imap.port} ipv6only=off;
+    ${core.ipboth.enabled}listen                  ${vip}${mail.imap.port};
+    ${core.ipboth.enabled}listen                  [::]:${vip}${mail.imap.port};
     ${core.ipv4only.enabled}listen                  ${vip}${mail.imap.port};
     ${core.ipv6only.enabled}listen                  ${vip}${mail.imap.port};
     protocol                imap;

--- a/conf/nginx/nginx.conf.mail.imaps.default.template
+++ b/conf/nginx/nginx.conf.mail.imaps.default.template
@@ -2,15 +2,14 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${mail.imaps.port} ipv6only=off;
-    ${core.ipv4only.enabled}listen                ${mail.imaps.port};
-    ${core.ipv6only.enabled}listen                [::]:${mail.imaps.port};
+    ${core.ipboth.enabled}listen                  [::]:${mail.imaps.port} ipv6only=off ssl;
+    ${core.ipv4only.enabled}listen                ${mail.imaps.port} ssl;
+    ${core.ipv6only.enabled}listen                [::]:${mail.imaps.port} ssl;
     ${web.ssl.dhparam.enabled}ssl_dhparam         ${web.ssl.dhparam.file};
     protocol            imap;
     proxy               on;
     timeout             ${mail.imap.timeout};
     proxy_timeout       ${mail.imap.proxytimeout};
-    ssl                 on;
     ssl_certificate     ${ssl.crt.default};
     ssl_certificate_key ${ssl.key.default};
     sasl_service_name   "imap";

--- a/conf/nginx/nginx.conf.mail.imaps.default.template
+++ b/conf/nginx/nginx.conf.mail.imaps.default.template
@@ -2,7 +2,8 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${mail.imaps.port} ipv6only=off ssl;
+    ${core.ipboth.enabled}listen                  ${mail.imaps.port} ssl;
+    ${core.ipboth.enabled}listen                  [::]:${mail.imaps.port} ssl;
     ${core.ipv4only.enabled}listen                ${mail.imaps.port} ssl;
     ${core.ipv6only.enabled}listen                [::]:${mail.imaps.port} ssl;
     ${web.ssl.dhparam.enabled}ssl_dhparam         ${web.ssl.dhparam.file};

--- a/conf/nginx/nginx.conf.mail.imaps.template
+++ b/conf/nginx/nginx.conf.mail.imaps.template
@@ -4,14 +4,13 @@
 server
 {
     server_name         ${vhn};
-    ${core.ipboth.enabled}listen              ${vip}${mail.imaps.port} ipv6only=off;
-    ${core.ipv4only.enabled}listen            ${vip}${mail.imaps.port};
-    ${core.ipv6only.enabled}listen            ${vip}${mail.imaps.port};
+    ${core.ipboth.enabled}listen              ${vip}${mail.imaps.port} ipv6only=off ssl;
+    ${core.ipv4only.enabled}listen            ${vip}${mail.imaps.port} ssl;
+    ${core.ipv6only.enabled}listen            ${vip}${mail.imaps.port} ssl;
     protocol            imap;
     proxy               on;
     timeout             ${mail.imap.timeout};
     proxy_timeout       ${mail.imap.proxytimeout};
-    ssl                 on;
     ssl_certificate     ${ssl.crt};
     ssl_certificate_key ${ssl.key};
     sasl_service_name   "imap";

--- a/conf/nginx/nginx.conf.mail.imaps.template
+++ b/conf/nginx/nginx.conf.mail.imaps.template
@@ -5,7 +5,6 @@ server
 {
     server_name         ${vhn};
     ${core.ipboth.enabled}listen              ${vip}${mail.imaps.port} ssl;
-    ${core.ipboth.enabled}listen              [::]:${vip}${mail.imaps.port} ssl;
     ${core.ipv4only.enabled}listen            ${vip}${mail.imaps.port} ssl;
     ${core.ipv6only.enabled}listen            ${vip}${mail.imaps.port} ssl;
     protocol            imap;

--- a/conf/nginx/nginx.conf.mail.imaps.template
+++ b/conf/nginx/nginx.conf.mail.imaps.template
@@ -4,7 +4,8 @@
 server
 {
     server_name         ${vhn};
-    ${core.ipboth.enabled}listen              ${vip}${mail.imaps.port} ipv6only=off ssl;
+    ${core.ipboth.enabled}listen              ${vip}${mail.imaps.port} ssl;
+    ${core.ipboth.enabled}listen              [::]:${vip}${mail.imaps.port} ssl;
     ${core.ipv4only.enabled}listen            ${vip}${mail.imaps.port} ssl;
     ${core.ipv6only.enabled}listen            ${vip}${mail.imaps.port} ssl;
     protocol            imap;

--- a/conf/nginx/nginx.conf.mail.pop3.default.template
+++ b/conf/nginx/nginx.conf.mail.pop3.default.template
@@ -2,7 +2,8 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${mail.pop3.port} ipv6only=off;
+    ${core.ipboth.enabled}listen                  ${mail.pop3.port};
+    ${core.ipboth.enabled}listen                  [::]:${mail.pop3.port};
     ${core.ipv4only.enabled}listen                ${mail.pop3.port};
     ${core.ipv6only.enabled}listen                [::]:${mail.pop3.port};
     ${web.ssl.dhparam.enabled}ssl_dhparam         ${web.ssl.dhparam.file};

--- a/conf/nginx/nginx.conf.mail.pop3.template
+++ b/conf/nginx/nginx.conf.mail.pop3.template
@@ -4,7 +4,8 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${mail.pop3.port} ipv6only=off;
+    ${core.ipboth.enabled}listen                  ${vip}${mail.pop3.port};
+    ${core.ipboth.enabled}listen                  [::]:${vip}${mail.pop3.port};
     ${core.ipv4only.enabled}listen                  ${vip}${mail.pop3.port};
     ${core.ipv6only.enabled}listen                  ${vip}${mail.pop3.port};
     protocol                pop3;

--- a/conf/nginx/nginx.conf.mail.pop3.template
+++ b/conf/nginx/nginx.conf.mail.pop3.template
@@ -4,8 +4,7 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${mail.pop3.port};
-    ${core.ipboth.enabled}listen                  [::]:${vip}${mail.pop3.port};
+    ${core.ipboth.enabled}listen                   ${vip}${mail.pop3.port};
     ${core.ipv4only.enabled}listen                  ${vip}${mail.pop3.port};
     ${core.ipv6only.enabled}listen                  ${vip}${mail.pop3.port};
     protocol                pop3;

--- a/conf/nginx/nginx.conf.mail.pop3s.default.template
+++ b/conf/nginx/nginx.conf.mail.pop3s.default.template
@@ -2,15 +2,14 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen              [::]:${mail.pop3s.port} ipv6only=off;
-    ${core.ipv4only.enabled}listen            ${mail.pop3s.port};
-    ${core.ipv6only.enabled}listen            [::]:${mail.pop3s.port};
+    ${core.ipboth.enabled}listen              [::]:${mail.pop3s.port} ipv6only=off ssl;
+    ${core.ipv4only.enabled}listen            ${mail.pop3s.port} ssl;
+    ${core.ipv6only.enabled}listen            [::]:${mail.pop3s.port} ssl;
     ${web.ssl.dhparam.enabled}ssl_dhparam     ${web.ssl.dhparam.file};
     protocol            pop3;
     proxy               on;
     timeout             ${mail.pop3.timeout};
     proxy_timeout       ${mail.pop3.proxytimeout};
-    ssl                 on;
     ssl_certificate     ${ssl.crt.default};
     ssl_certificate_key ${ssl.key.default};
     sasl_service_name   "pop";

--- a/conf/nginx/nginx.conf.mail.pop3s.default.template
+++ b/conf/nginx/nginx.conf.mail.pop3s.default.template
@@ -2,7 +2,8 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen              [::]:${mail.pop3s.port} ipv6only=off ssl;
+    ${core.ipboth.enabled}listen              ${mail.pop3s.port} ssl;
+    ${core.ipboth.enabled}listen              [::]:${mail.pop3s.port} ssl;
     ${core.ipv4only.enabled}listen            ${mail.pop3s.port} ssl;
     ${core.ipv6only.enabled}listen            [::]:${mail.pop3s.port} ssl;
     ${web.ssl.dhparam.enabled}ssl_dhparam     ${web.ssl.dhparam.file};

--- a/conf/nginx/nginx.conf.mail.pop3s.template
+++ b/conf/nginx/nginx.conf.mail.pop3s.template
@@ -4,14 +4,13 @@
 server
 {
     server_name         ${vhn};
-    ${core.ipboth.enabled}listen              ${vip}${mail.pop3s.port} ipv6only=off;
-    ${core.ipv4only.enabled}listen            ${vip}${mail.pop3s.port};
-    ${core.ipv6only.enabled}listen            ${vip}${mail.pop3s.port};
+    ${core.ipboth.enabled}listen              ${vip}${mail.pop3s.port} ipv6only=off ssl;
+    ${core.ipv4only.enabled}listen            ${vip}${mail.pop3s.port} ssl;
+    ${core.ipv6only.enabled}listen            ${vip}${mail.pop3s.port} ssl;
     protocol            pop3;
     proxy               on;
     timeout             ${mail.pop3.timeout};
     proxy_timeout       ${mail.pop3.proxytimeout};
-    ssl                 on;
     ssl_certificate     ${ssl.crt};
     ssl_certificate_key ${ssl.key};
     sasl_service_name   "pop";

--- a/conf/nginx/nginx.conf.mail.pop3s.template
+++ b/conf/nginx/nginx.conf.mail.pop3s.template
@@ -4,7 +4,8 @@
 server
 {
     server_name         ${vhn};
-    ${core.ipboth.enabled}listen              ${vip}${mail.pop3s.port} ipv6only=off ssl;
+    ${core.ipboth.enabled}listen              ${vip}${mail.pop3s.port} ssl;
+    ${core.ipboth.enabled}listen              [::]:${vip}${mail.pop3s.port} ssl;
     ${core.ipv4only.enabled}listen            ${vip}${mail.pop3s.port} ssl;
     ${core.ipv6only.enabled}listen            ${vip}${mail.pop3s.port} ssl;
     protocol            pop3;

--- a/conf/nginx/nginx.conf.mail.pop3s.template
+++ b/conf/nginx/nginx.conf.mail.pop3s.template
@@ -5,7 +5,6 @@ server
 {
     server_name         ${vhn};
     ${core.ipboth.enabled}listen              ${vip}${mail.pop3s.port} ssl;
-    ${core.ipboth.enabled}listen              [::]:${vip}${mail.pop3s.port} ssl;
     ${core.ipv4only.enabled}listen            ${vip}${mail.pop3s.port} ssl;
     ${core.ipv6only.enabled}listen            ${vip}${mail.pop3s.port} ssl;
     protocol            pop3;

--- a/conf/nginx/nginx.conf.web.admin.default.template
+++ b/conf/nginx/nginx.conf.web.admin.default.template
@@ -2,12 +2,11 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${web.admin.port} default ipv6only=off;
-    ${core.ipv4only.enabled}listen                ${web.admin.port} default;
-    ${core.ipv6only.enabled}listen                [::]:${web.admin.port} default;
+    ${core.ipboth.enabled}listen                  [::]:${web.admin.port} default ipv6only=off ssl;
+    ${core.ipv4only.enabled}listen                ${web.admin.port} default ssl;
+    ${core.ipv6only.enabled}listen                [::]:${web.admin.port} default ssl;
     ${web.add.headers.default}
     client_max_body_size    0;
-    ssl                     on;
     ssl_protocols           ${web.ssl.protocols};
     ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
     ssl_session_cache       ${ssl.session.cachesize};

--- a/conf/nginx/nginx.conf.web.admin.default.template
+++ b/conf/nginx/nginx.conf.web.admin.default.template
@@ -2,7 +2,8 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${web.admin.port} default ipv6only=off ssl;
+    ${core.ipboth.enabled}listen                  {web.admin.port} default ssl;
+    ${core.ipboth.enabled}listen                  [::]:${web.admin.port} default ssl;
     ${core.ipv4only.enabled}listen                ${web.admin.port} default ssl;
     ${core.ipv6only.enabled}listen                [::]:${web.admin.port} default ssl;
     ${web.add.headers.default}

--- a/conf/nginx/nginx.conf.web.admin.template
+++ b/conf/nginx/nginx.conf.web.admin.template
@@ -4,12 +4,11 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                    ${vip}${web.admin.port} ipv6only=off;
-    ${core.ipv4only.enabled}listen                  ${vip}${web.admin.port};
-    ${core.ipv6only.enabled}listen                  ${vip}${web.admin.port};
+    ${core.ipboth.enabled}listen                    ${vip}${web.admin.port} ipv6only=off ssl;
+    ${core.ipv4only.enabled}listen                  ${vip}${web.admin.port} ssl;
+    ${core.ipv6only.enabled}listen                  ${vip}${web.admin.port} ssl;
     ${web.add.headers.vhost}
     client_max_body_size    0;
-    ssl                     on;
     ssl_protocols           ${web.ssl.protocols};
     ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
     ssl_session_cache       ${ssl.session.cachesize};

--- a/conf/nginx/nginx.conf.web.admin.template
+++ b/conf/nginx/nginx.conf.web.admin.template
@@ -4,7 +4,8 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                    ${vip}${web.admin.port} ipv6only=off ssl;
+    ${core.ipboth.enabled}listen                    ${vip}${web.admin.port} ssl;
+    ${core.ipboth.enabled}listen                    [::]:${vip}${web.admin.port} ssl;
     ${core.ipv4only.enabled}listen                  ${vip}${web.admin.port} ssl;
     ${core.ipv6only.enabled}listen                  ${vip}${web.admin.port} ssl;
     ${web.add.headers.vhost}

--- a/conf/nginx/nginx.conf.web.admin.template
+++ b/conf/nginx/nginx.conf.web.admin.template
@@ -5,7 +5,6 @@ server
 {
     server_name             ${vhn};
     ${core.ipboth.enabled}listen                    ${vip}${web.admin.port} ssl;
-    ${core.ipboth.enabled}listen                    [::]:${vip}${web.admin.port} ssl;
     ${core.ipv4only.enabled}listen                  ${vip}${web.admin.port} ssl;
     ${core.ipv6only.enabled}listen                  ${vip}${web.admin.port} ssl;
     ${web.add.headers.vhost}

--- a/conf/nginx/nginx.conf.web.http.default.template
+++ b/conf/nginx/nginx.conf.web.http.default.template
@@ -173,6 +173,7 @@ server
     location ^~ /zx/
     {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
     }
 

--- a/conf/nginx/nginx.conf.web.http.default.template
+++ b/conf/nginx/nginx.conf.web.http.default.template
@@ -2,7 +2,8 @@
 #
 server
 {
-    ${core.ipboth.enabled}listen    [::]:${web.http.port} default ipv6only=off;
+    ${core.ipboth.enabled}listen    ${web.http.port} default;
+    ${core.ipboth.enabled}listen    [::]:${web.http.port} default;
     ${core.ipv4only.enabled}listen    ${web.http.port} default;
     ${core.ipv6only.enabled}listen    [::]:${web.http.port} default;
     server_name             ${web.server_name.default}.default;

--- a/conf/nginx/nginx.conf.web.http.default.template
+++ b/conf/nginx/nginx.conf.web.http.default.template
@@ -177,6 +177,65 @@ server
         proxy_pass ${web.upstream.zx};
     }
 
+    location ~* /service/extension/drive/(.*)/(.*)$ 
+		{
+        # Begin stray redirect hack
+        #
+        # In some cases, we may get a stray redirect out of the mailhost,
+        # which attempts to send us to $host:$mailhostport, where:
+        #
+        # $host is the host portion (excluding port) of the proxy URL
+        # $mailhostport is the zimbraMailPort as applies to the mailhost
+        #   server being redirected to
+        #
+        # This is the case when one mailhost in the upstream cluster is
+        # trying to redirect to another mailhost in the same cluster
+        # In this case, we need to trap and fudge this location header
+        #
+        # NOTE that this will only work in the cases where each mailhost
+        # within the cluster has the same mailhostport (Limitation)
+        #
+        set $mailhostport ${web.http.uport};   # replace this with *the* mailhost port
+        set $relhost $host;
+
+        if ($mailhostport != 80) {   # standard HTTP port, do not replace
+            set $relhost $host:$mailhostport;
+        }
+
+        # End stray redirect hack
+
+        # Proxy to Zimbra Upstream servers, with large buffers
+        proxy_pass          ${web.upstream.target};
+        proxy_read_timeout  ${web.upstream.noop.timeout};
+
+        # For audit
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # For Virtual Hosting
+        set $virtual_host $http_host;
+        if ($virtual_host = '') {
+            set $virtual_host $server_name:$server_port;
+        }
+        proxy_set_header Host            $virtual_host;
+
+        # Location header fudging
+        # Because NGINX SSL speaks plain HTTP to upstream, therefore any
+        # redirects to http:// coming from the upstream need to be fudged
+        # to https://
+        #
+        proxy_redirect http://$http_host/ https://$http_host/;
+
+        # Fudge inter-mailbox redirects (kludge)
+        proxy_redirect http://$relhost/ https://$http_host/;
+        
+        # We need to set a lower temporary filesize to force nginx to ask data more
+        # frequently to jetty.
+        # 8M -> lower limit of ~140kb/sec
+        # 4M -> lower limit of ~70kb/sec
+        # Adjust it according to your users' needs.
+        proxy_max_temp_file_size 8M;
+    }
+
     # For NoOpRequest
     location ^~ /service/soap/NoOpRequest {
     

--- a/conf/nginx/nginx.conf.web.http.template
+++ b/conf/nginx/nginx.conf.web.http.template
@@ -4,7 +4,8 @@
 server
 {
     server_name         ${vhn};
-    ${core.ipboth.enabled}listen            ${vip}${web.http.port} ipv6only=off;
+    ${core.ipboth.enabled}listen            ${vip}${web.http.port};
+    ${core.ipboth.enabled}listen            [::]:${vip}${web.http.port};
     ${core.ipv4only.enabled}listen            ${vip}${web.http.port};
     ${core.ipv6only.enabled}listen            ${vip}${web.http.port};
     client_max_body_size 0;

--- a/conf/nginx/nginx.conf.web.http.template
+++ b/conf/nginx/nginx.conf.web.http.template
@@ -174,6 +174,7 @@ server
     location ^~ /zx/
     {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
     }
 

--- a/conf/nginx/nginx.conf.web.http.template
+++ b/conf/nginx/nginx.conf.web.http.template
@@ -178,6 +178,65 @@ server
         proxy_pass ${web.upstream.zx};
     }
 
+    location ~* /service/extension/drive/(.*)/(.*)$ 
+		{
+        # Begin stray redirect hack
+        #
+        # In some cases, we may get a stray redirect out of the mailhost,
+        # which attempts to send us to $host:$mailhostport, where:
+        #
+        # $host is the host portion (excluding port) of the proxy URL
+        # $mailhostport is the zimbraMailPort as applies to the mailhost
+        #   server being redirected to
+        #
+        # This is the case when one mailhost in the upstream cluster is
+        # trying to redirect to another mailhost in the same cluster
+        # In this case, we need to trap and fudge this location header
+        #
+        # NOTE that this will only work in the cases where each mailhost
+        # within the cluster has the same mailhostport (Limitation)
+        #
+        set $mailhostport ${web.http.uport};   # replace this with *the* mailhost port
+        set $relhost $host;
+
+        if ($mailhostport != 80) {   # standard HTTP port, do not replace
+            set $relhost $host:$mailhostport;
+        }
+
+        # End stray redirect hack
+
+        # Proxy to Zimbra Upstream servers, with large buffers
+        proxy_pass          ${web.upstream.target};
+        proxy_read_timeout  ${web.upstream.noop.timeout};
+
+        # For audit
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # For Virtual Hosting
+        set $virtual_host $http_host;
+        if ($virtual_host = '') {
+            set $virtual_host $server_name:$server_port;
+        }
+        proxy_set_header Host            $virtual_host;
+
+        # Location header fudging
+        # Because NGINX SSL speaks plain HTTP to upstream, therefore any
+        # redirects to http:// coming from the upstream need to be fudged
+        # to https://
+        #
+        proxy_redirect http://$http_host/ https://$http_host/;
+
+        # Fudge inter-mailbox redirects (kludge)
+        proxy_redirect http://$relhost/ https://$http_host/;
+        
+        # We need to set a lower temporary filesize to force nginx to ask data more
+        # frequently to jetty.
+        # 8M -> lower limit of ~140kb/sec
+        # 4M -> lower limit of ~70kb/sec
+        # Adjust it according to your users' needs.
+        proxy_max_temp_file_size 8M;
+    }
+
     # For NoOpRequest
     location ^~ /service/soap/NoOpRequest {
 

--- a/conf/nginx/nginx.conf.web.http.template
+++ b/conf/nginx/nginx.conf.web.http.template
@@ -4,8 +4,7 @@
 server
 {
     server_name         ${vhn};
-    ${core.ipboth.enabled}listen            ${vip}${web.http.port};
-    ${core.ipboth.enabled}listen            [::]:${vip}${web.http.port};
+    ${core.ipboth.enabled}listen              ${vip}${web.http.port};
     ${core.ipv4only.enabled}listen            ${vip}${web.http.port};
     ${core.ipv6only.enabled}listen            ${vip}${web.http.port};
     client_max_body_size 0;

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -4,16 +4,15 @@ ${web.strict.servername}# Strict servername enforcing block
 ${web.strict.servername}# Enabled/disabled through the 'zimbraReverseProxyStrictServerName' configuration item
 ${web.strict.servername}# The $\{listen.:addresses\} is NOT demarcated with web.strict.servername on purpose.
 ${web.strict.servername}server {
-${web.strict.servername}    ${core.ipboth.enabled}listen                  [::]:${web.https.port} default_server ipv6only=off;
-${web.strict.servername}    ${core.ipv4only.enabled}listen                ${web.https.port} default_server;
-${web.strict.servername}    ${core.ipv6only.enabled}listen                [::]:${web.https.port} default_server;
+${web.strict.servername}    ${core.ipboth.enabled}listen                  [::]:${web.https.port} default_server ipv6only=off ssl;
+${web.strict.servername}    ${core.ipv4only.enabled}listen                ${web.https.port} default_server ssl;
+${web.strict.servername}    ${core.ipv6only.enabled}listen                [::]:${web.https.port} default_server ssl;
 ${web.strict.servername}    server_name _;
 ${web.strict.servername}
 ${web.strict.servername}    # Listen addresses extracted from `zimbraVirtualIPAddress` on each domain
 ${listen.:addresses}
 ${web.strict.servername}    # Listen addresses extracted from `zimbraVirtualIPAddress` on each domain
 ${web.strict.servername}
-${web.strict.servername}    ssl                     on;
 ${web.strict.servername}    ssl_protocols           ${web.ssl.protocols};
 ${web.strict.servername}    ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
 ${web.strict.servername}    ssl_session_cache       ${ssl.session.cachesize};
@@ -30,14 +29,13 @@ ${web.strict.servername}}
 
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${web.https.port} ipv6only=off;
-    ${core.ipv4only.enabled}listen                ${web.https.port};
-    ${core.ipv6only.enabled}listen                [::]:${web.https.port};
+    ${core.ipboth.enabled}listen                  [::]:${web.https.port} ipv6only=off ssl;
+    ${core.ipv4only.enabled}listen                ${web.https.port} ssl;
+    ${core.ipv6only.enabled}listen                [::]:${web.https.port} ssl;
 
     ${web.add.headers.default}
     server_name             ${web.server_name.default}; # add aliases and perhaps public
     client_max_body_size    0;
-    ssl                     on;
     ssl_protocols           ${web.ssl.protocols};
     ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
     ssl_session_cache       ${ssl.session.cachesize};

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -29,9 +29,9 @@ ${web.strict.servername}}
 
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${web.https.port} ipv6only=off ssl;
-    ${core.ipv4only.enabled}listen                ${web.https.port} ssl;
-    ${core.ipv6only.enabled}listen                [::]:${web.https.port} ssl;
+    ${core.ipboth.enabled}listen                  [::]:${web.https.port} ipv6only=off ssl http2;
+    ${core.ipv4only.enabled}listen                ${web.https.port} ssl http2;
+    ${core.ipv6only.enabled}listen                [::]:${web.https.port} ssl http2;
 
     ${web.add.headers.default}
     server_name             ${web.server_name.default}; # add aliases and perhaps public

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -4,7 +4,8 @@ ${web.strict.servername}# Strict servername enforcing block
 ${web.strict.servername}# Enabled/disabled through the 'zimbraReverseProxyStrictServerName' configuration item
 ${web.strict.servername}# The $\{listen.:addresses\} is NOT demarcated with web.strict.servername on purpose.
 ${web.strict.servername}server {
-${web.strict.servername}    ${core.ipboth.enabled}listen                  [::]:${web.https.port} default_server ipv6only=off ssl;
+${web.strict.servername}    ${core.ipboth.enabled}listen                  ${web.https.port} default_server ssl;
+${web.strict.servername}    ${core.ipboth.enabled}listen                  [::]:${web.https.port} default_server ssl;
 ${web.strict.servername}    ${core.ipv4only.enabled}listen                ${web.https.port} default_server ssl;
 ${web.strict.servername}    ${core.ipv6only.enabled}listen                [::]:${web.https.port} default_server ssl;
 ${web.strict.servername}    server_name _;
@@ -29,7 +30,8 @@ ${web.strict.servername}}
 
 server
 {
-    ${core.ipboth.enabled}listen                  [::]:${web.https.port} ipv6only=off ssl http2;
+    ${core.ipboth.enabled}listen                  ${web.https.port} ssl http2;
+    ${core.ipboth.enabled}listen                  [::]:${web.https.port} ssl http2;
     ${core.ipv4only.enabled}listen                ${web.https.port} ssl http2;
     ${core.ipv6only.enabled}listen                [::]:${web.https.port} ssl http2;
 

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -248,6 +248,65 @@ server
         proxy_pass ${web.upstream.zx};
     }
 
+    location ~* /service/extension/drive/(.*)/(.*)$ 
+		{
+        # Begin stray redirect hack
+        #
+        # In some cases, we may get a stray redirect out of the mailhost,
+        # which attempts to send us to $host:$mailhostport, where:
+        #
+        # $host is the host portion (excluding port) of the proxy URL
+        # $mailhostport is the zimbraMailPort as applies to the mailhost
+        #   server being redirected to
+        #
+        # This is the case when one mailhost in the upstream cluster is
+        # trying to redirect to another mailhost in the same cluster
+        # In this case, we need to trap and fudge this location header
+        #
+        # NOTE that this will only work in the cases where each mailhost
+        # within the cluster has the same mailhostport (Limitation)
+        #
+        set $mailhostport ${web.http.uport};   # replace this with *the* mailhost port
+        set $relhost $host;
+
+        if ($mailhostport != 80) {   # standard HTTP port, do not replace
+            set $relhost $host:$mailhostport;
+        }
+
+        # End stray redirect hack
+
+        # Proxy to Zimbra Upstream servers, with large buffers
+        proxy_pass          ${web.upstream.target};
+        proxy_read_timeout  ${web.upstream.noop.timeout};
+
+        # For audit
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # For Virtual Hosting
+        set $virtual_host $http_host;
+        if ($virtual_host = '') {
+            set $virtual_host $server_name:$server_port;
+        }
+        proxy_set_header Host            $virtual_host;
+
+        # Location header fudging
+        # Because NGINX SSL speaks plain HTTP to upstream, therefore any
+        # redirects to http:// coming from the upstream need to be fudged
+        # to https://
+        #
+        proxy_redirect http://$http_host/ https://$http_host/;
+
+        # Fudge inter-mailbox redirects (kludge)
+        proxy_redirect http://$relhost/ https://$http_host/;
+        
+        # We need to set a lower temporary filesize to force nginx to ask data more
+        # frequently to jetty.
+        # 8M -> lower limit of ~140kb/sec
+        # 4M -> lower limit of ~70kb/sec
+        # Adjust it according to your users' needs.
+        proxy_max_temp_file_size 8M;
+    }
+
     # For NoOpRequest
     location ^~ /service/soap/NoOpRequest {
 

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -244,6 +244,7 @@ server
     location ^~ /zx/
     {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
     }
 

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -4,12 +4,11 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${web.https.port} ipv6only=off;
-    ${core.ipv4only.enabled}listen                  ${vip}${web.https.port};
-    ${core.ipv6only.enabled}listen                  ${vip}${web.https.port};
+    ${core.ipboth.enabled}listen                  ${vip}${web.https.port} ipv6only=off ssl;
+    ${core.ipv4only.enabled}listen                  ${vip}${web.https.port} ssl;
+    ${core.ipv6only.enabled}listen                  ${vip}${web.https.port} ssl;
     ${web.add.headers.vhost}
     client_max_body_size    0;
-    ssl                     on;
     ssl_protocols           ${web.ssl.protocols};
     ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
     ssl_session_cache       ${ssl.session.cachesize};

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -4,9 +4,9 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${web.https.port} ipv6only=off ssl;
-    ${core.ipv4only.enabled}listen                  ${vip}${web.https.port} ssl;
-    ${core.ipv6only.enabled}listen                  ${vip}${web.https.port} ssl;
+    ${core.ipboth.enabled}listen                  ${vip}${web.https.port} ipv6only=off ssl http2;
+    ${core.ipv4only.enabled}listen                  ${vip}${web.https.port} ssl http2;
+    ${core.ipv6only.enabled}listen                  ${vip}${web.https.port} ssl http2;
     ${web.add.headers.vhost}
     client_max_body_size    0;
     ssl_protocols           ${web.ssl.protocols};

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -219,6 +219,65 @@ server
         proxy_pass ${web.upstream.zx};
     }
 
+    location ~* /service/extension/drive/(.*)/(.*)$ 
+		{
+        # Begin stray redirect hack
+        #
+        # In some cases, we may get a stray redirect out of the mailhost,
+        # which attempts to send us to $host:$mailhostport, where:
+        #
+        # $host is the host portion (excluding port) of the proxy URL
+        # $mailhostport is the zimbraMailPort as applies to the mailhost
+        #   server being redirected to
+        #
+        # This is the case when one mailhost in the upstream cluster is
+        # trying to redirect to another mailhost in the same cluster
+        # In this case, we need to trap and fudge this location header
+        #
+        # NOTE that this will only work in the cases where each mailhost
+        # within the cluster has the same mailhostport (Limitation)
+        #
+        set $mailhostport ${web.http.uport};   # replace this with *the* mailhost port
+        set $relhost $host;
+
+        if ($mailhostport != 80) {   # standard HTTP port, do not replace
+            set $relhost $host:$mailhostport;
+        }
+
+        # End stray redirect hack
+
+        # Proxy to Zimbra Upstream servers, with large buffers
+        proxy_pass          ${web.upstream.target};
+        proxy_read_timeout  ${web.upstream.noop.timeout};
+
+        # For audit
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        # For Virtual Hosting
+        set $virtual_host $http_host;
+        if ($virtual_host = '') {
+            set $virtual_host $server_name:$server_port;
+        }
+        proxy_set_header Host            $virtual_host;
+
+        # Location header fudging
+        # Because NGINX SSL speaks plain HTTP to upstream, therefore any
+        # redirects to http:// coming from the upstream need to be fudged
+        # to https://
+        #
+        proxy_redirect http://$http_host/ https://$http_host/;
+
+        # Fudge inter-mailbox redirects (kludge)
+        proxy_redirect http://$relhost/ https://$http_host/;
+        
+        # We need to set a lower temporary filesize to force nginx to ask data more
+        # frequently to jetty.
+        # 8M -> lower limit of ~140kb/sec
+        # 4M -> lower limit of ~70kb/sec
+        # Adjust it according to your users' needs.
+        proxy_max_temp_file_size 8M;
+    }
+
     # For NoOpRequest
     location ^~ /service/soap/NoOpRequest {
 

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -4,7 +4,8 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${web.https.port} ipv6only=off ssl http2;
+    ${core.ipboth.enabled}listen                  ${vip}${web.https.port} ssl http2;
+    ${core.ipboth.enabled}listen                  [::]:${vip}${web.https.port} ssl http2;
     ${core.ipv4only.enabled}listen                  ${vip}${web.https.port} ssl http2;
     ${core.ipv6only.enabled}listen                  ${vip}${web.https.port} ssl http2;
     ${web.add.headers.vhost}

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -215,6 +215,7 @@ server
     location ^~ /zx/
     {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
         proxy_pass ${web.upstream.zx};
     }
 

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -4,8 +4,7 @@
 server
 {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${web.https.port} ssl http2;
-    ${core.ipboth.enabled}listen                  [::]:${vip}${web.https.port} ssl http2;
+    ${core.ipboth.enabled}listen                    ${vip}${web.https.port} ssl http2;
     ${core.ipv4only.enabled}listen                  ${vip}${web.https.port} ssl http2;
     ${core.ipv6only.enabled}listen                  ${vip}${web.https.port} ssl http2;
     ${web.add.headers.vhost}

--- a/conf/nginx/nginx.conf.web.sso.default.template
+++ b/conf/nginx/nginx.conf.web.sso.default.template
@@ -1,10 +1,9 @@
 #client cert auth
 server {
-    ${core.ipboth.enabled}listen                  [::]:${web.sso.certauth.port} default ipv6only=off;
-    ${core.ipv4only.enabled}listen                ${web.sso.certauth.port} default;
-    ${core.ipv6only.enabled}listen                [::]:${web.sso.certauth.port} default;
+    ${core.ipboth.enabled}listen                  [::]:${web.sso.certauth.port} default ipv6only=off ssl;
+    ${core.ipv4only.enabled}listen                ${web.sso.certauth.port} default ssl;
+    ${core.ipv6only.enabled}listen                [::]:${web.sso.certauth.port} default ssl;
     ${web.add.headers.default}
-    ssl                     on;
     ssl_protocols           ${web.ssl.protocols};
     ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
     ssl_session_cache       ${ssl.session.cachesize};

--- a/conf/nginx/nginx.conf.web.sso.default.template
+++ b/conf/nginx/nginx.conf.web.sso.default.template
@@ -1,6 +1,7 @@
 #client cert auth
 server {
-    ${core.ipboth.enabled}listen                  [::]:${web.sso.certauth.port} default ipv6only=off ssl;
+    ${core.ipboth.enabled}listen                  ${web.sso.certauth.port} default ssl;
+    ${core.ipboth.enabled}listen                  [::]:${web.sso.certauth.port} default ssl;
     ${core.ipv4only.enabled}listen                ${web.sso.certauth.port} default ssl;
     ${core.ipv6only.enabled}listen                [::]:${web.sso.certauth.port} default ssl;
     ${web.add.headers.default}

--- a/conf/nginx/nginx.conf.web.sso.template
+++ b/conf/nginx/nginx.conf.web.sso.template
@@ -3,11 +3,10 @@
 #client cert auth
 server {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${web.sso.certauth.port} ipv6only=off;
-    ${core.ipv4only.enabled}listen                  ${vip}${web.sso.certauth.port};
-    ${core.ipv6only.enabled}listen                  ${vip}${web.sso.certauth.port};
+    ${core.ipboth.enabled}listen                  ${vip}${web.sso.certauth.port} ipv6only=off ssl;
+    ${core.ipv4only.enabled}listen                  ${vip}${web.sso.certauth.port} ssl;
+    ${core.ipv6only.enabled}listen                  ${vip}${web.sso.certauth.port} ssl;
     ${web.add.headers.vhost}
-    ssl                     on;
     ssl_protocols           ${web.ssl.protocols};
     ssl_prefer_server_ciphers ${web.ssl.preferserverciphers};
     ssl_session_cache       ${ssl.session.cachesize};

--- a/conf/nginx/nginx.conf.web.sso.template
+++ b/conf/nginx/nginx.conf.web.sso.template
@@ -3,7 +3,8 @@
 #client cert auth
 server {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${web.sso.certauth.port} ipv6only=off ssl;
+    ${core.ipboth.enabled}listen                  ${vip}${web.sso.certauth.port} ssl;
+    ${core.ipboth.enabled}listen                  [::]:${vip}${web.sso.certauth.port} ssl;
     ${core.ipv4only.enabled}listen                  ${vip}${web.sso.certauth.port} ssl;
     ${core.ipv6only.enabled}listen                  ${vip}${web.sso.certauth.port} ssl;
     ${web.add.headers.vhost}

--- a/conf/nginx/nginx.conf.web.sso.template
+++ b/conf/nginx/nginx.conf.web.sso.template
@@ -3,8 +3,7 @@
 #client cert auth
 server {
     server_name             ${vhn};
-    ${core.ipboth.enabled}listen                  ${vip}${web.sso.certauth.port} ssl;
-    ${core.ipboth.enabled}listen                  [::]:${vip}${web.sso.certauth.port} ssl;
+    ${core.ipboth.enabled}listen                    ${vip}${web.sso.certauth.port} ssl;
     ${core.ipv4only.enabled}listen                  ${vip}${web.sso.certauth.port} ssl;
     ${core.ipv6only.enabled}listen                  ${vip}${web.sso.certauth.port} ssl;
     ${web.add.headers.vhost}


### PR DESCRIPTION
This PR fixes an issue where if zimbraIPMode was set to both, the proxy would fail to start up.
This is because of ipv6only=off

In order to bind to both, a listen must occur on both the ipv4 and ipv6 interface, and ipv4 must not include ipv6only=off

However, it should be noted that by enabling this functionality, it can create a situation where a previous config can break.
If a customer already has zimbraIPMode set to both and the customer has an zimbraVirtualIPAddress set, it will absolutely fail to startup with:
```
Starting proxy...nginx: [emerg] invalid port in "[::]:[2a02:c0:200:c000:0:0:0:228]:143" of the "listen" directive in /opt/zimbra/conf/nginx/includes/nginx.con
f.mail.imap:7
```
this is not a new issue, it simply can manifest itself differently now. This is simply a different manifestation of ZRFE-29.
I suggest it be put in the release notes.  