### PR TITLE
ZBUG-2706 Stop unauthenticated user from poison the memcached

### DIFF
--- a/conf/nginx/nginx.conf.web.http.default.template
+++ b/conf/nginx/nginx.conf.web.http.default.template
@@ -435,6 +435,11 @@ server
     
     location ~* /(service|principals|dav|\.well-known|home|octopus|shf|user|certauth|spnegoauth|(zimbra/home)|(zimbra/user))/
     {
+        # ZBUG-2706 Memcached poisoning with unauthenticated request
+        if ($request_uri ~* "%0A|%0D") {
+            return 403;
+        }
+
         # Begin stray redirect hack
         #
         # In some cases, we may get a stray redirect out of the mailhost,

--- a/conf/nginx/nginx.conf.web.http.template
+++ b/conf/nginx/nginx.conf.web.http.template
@@ -436,6 +436,11 @@ server
 
     location ~* /(service|principals|dav|\.well-known|home|octopus|shf|user|certauth|spnegoauth|(zimbra/home)|(zimbra/user))/
     {
+        # ZBUG-2706 Memcached poisoning with unauthenticated request
+        if ($request_uri ~* "%0A|%0D") {
+            return 403;
+        }
+
         # Begin stray redirect hack
         #
         # In some cases, we may get a stray redirect out of the mailhost,

--- a/conf/nginx/nginx.conf.web.https.default.template
+++ b/conf/nginx/nginx.conf.web.https.default.template
@@ -546,6 +546,11 @@ server
 
     location ~* /(service|principals|dav|\.well-known|home|octopus|shf|user|certauth|spnegoauth|(zimbra/home)|(zimbra/user))/
     {
+        # ZBUG-2706  Memcached poisoning with unauthenticated request
+        if ($request_uri ~* "%0A|%0D") {
+            return 403;
+        }
+
         # Begin stray redirect hack
         #
         # In some cases, we may get a stray redirect out of the mailhost,

--- a/conf/nginx/nginx.conf.web.https.template
+++ b/conf/nginx/nginx.conf.web.https.template
@@ -502,6 +502,11 @@ server
 
     location ~* /(service|principals|dav|\.well-known|home|octopus|shf|user|certauth|spnegoauth|(zimbra/home)|(zimbra/user))/
     {
+        # ZBUG-2706 Memcached poisoning with unauthenticated request
+        if ($request_uri ~* "%0A|%0D") {
+            return 403;
+        }
+
         # Begin stray redirect hack
         #
         # In some cases, we may get a stray redirect out of the mailhost,


### PR DESCRIPTION
**Problem:**
This vulnerability allows an unauthenticated attacker to inject arbitrary Memcache commands into a targeted instance. As a result, the attacker can overwrite arbitrary cached entries.

**Solution:** 
Reject %0D and %0A in any case and apply changes in the template file and solve the issue at Nginx level.